### PR TITLE
Add apps script manifest keys per the Google documentation.

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,4 +1,11 @@
 {
+  "addOns": {
+    "common": {
+      "name": "AWS Pricing by Strake™",
+      "logoUrl": "https://cdn.x.macroscope.io/assets/aws-pricing/logo.png"
+    },
+    "sheets": {}
+  },
   "dependencies": {
   },
   "exceptionLogging": "STACKDRIVER",
@@ -9,6 +16,13 @@
   "oauthScopes": [
     "https://www.googleapis.com/auth/script.container.ui",
     "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/userinfo.profile",
     "https://www.googleapis.com/auth/userinfo.email"
+
+  ],
+  "timeZone": "America/Denver",
+  "urlFetchWhitelist": [
+    "https://cdn.x.macroscope.io/aws-pricing/"
   ]
 }


### PR DESCRIPTION
These changes have been pushed to `HEAD` for this Apps Script project: https://script.google.com/home/projects/16NEz3gxliBMxKLeoXaEZfYwtKnecN3OOTgrFgAP9HqN0SjRHaPW_SSKa

The manifest has been updated with information that the Google documentation mentions as required. Once the manifest was updated it became possible to install the add-on in a test state.

See: https://developers.google.com/apps-script/add-ons/concepts/workspace-manifests

