### PR TITLE
Fix link to document in sidebar, should open new tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ pnpm-lock.yaml
 src/Test.js
 src/analytics/credentials/
 Test.js
-allfiles.js
+help_dialog_collapsed.html

--- a/Help.md
+++ b/Help.md
@@ -153,4 +153,3 @@ Storage type can be "aurora", "gp2", "piops" and "magnetic"
 ### Backwards compatibility
 
 This add-on is compatible with a previous version, allowing you to continue using the function notation from that version in your sheets. However, note that the sheets editor's pop-up suggestion feature will not be available. For more information about the formulas from version 1, please refer to [the following link](https://github.com/getmacroscope/aws-pricing/blob/master/Help.md)
-

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ help-dialog: help_dialog_collapsed.html
 
 # New version, adds collapsible headers
 # replaces h3 headers with buttons and content below in a div to make collapsible headers
-help_dialog.html: Help.md assets/templates/help_dialog_collapsed.html
-	echo "$$(npx marked Help.md) </div>" | sed -e '/__CONTENT__/{r /dev/stdin' -e 'd;}' \
+help_dialog_collapsed.html: Help.md assets/templates/help_dialog_collapsed.html
+	echo "$$(npx marked Help.md | sed 's/<a href/<a target="_blank" href/g') </div>" | sed -e '/__CONTENT__/{r /dev/stdin' -e 'd;}' \
 		assets/templates/help_dialog_collapsed.html | \
 		sed -E 's/<h3([^>]*)>/<\/div><button type="button" class="collapsible">/g' | \
 		sed -E 's/<\/h3>/<\/button>\n<div class="content">/g' | \

--- a/help_dialog_collapsed.html
+++ b/help_dialog_collapsed.html
@@ -267,7 +267,7 @@ Both functions take the number of <em>iops</em> in the parameter <code>volumeSiz
 <p>Storage type can be &quot;aurora&quot;, &quot;gp2&quot;, &quot;piops&quot; and &quot;magnetic&quot;</p>
 </div><button type="button" class="collapsible">Backwards compatibility</button>
 <div class="content">
-<p>This add-on is compatible with a previous version, allowing you to continue using the function notation from that version in your sheets. However, note that the sheets editor&#39;s pop-up suggestion feature will not be available. For more information about the formulas from version 1, please refer to <a href="https://github.com/getmacroscope/aws-pricing/blob/master/Help.md">the following link</a></p> </div>
+<p>This add-on is compatible with a previous version, allowing you to continue using the function notation from that version in your sheets. However, note that the sheets editor&#39;s pop-up suggestion feature will not be available. For more information about the formulas from version 1, please refer to <a target="_blank" href="https://github.com/getmacroscope/aws-pricing/blob/master/Help.md">the following link</a></p> </div>
 </div>
 
 <div id="tooltip" display="none" style="position: absolute; display: none;"></div>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "gencode": "./scripts/gen-funcs.rb",
-    "create-help-dialog": "make help-dialog",
-    "deploy": "npm run gencode && make help-dialog && clasp push"
+    "create-help-dialog": "make help_dialog_collapsed.html",
+    "deploy": "npm run gencode && make help_dialog_collapsed.html && clasp push"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
At the bottom of the sidebar (Menu -> How to use AWS Pricing) the link under backwards compatible does not work. 
- It's fixed now by opening up new tab. 